### PR TITLE
Launch command changes to bringup fusion360

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 `$ fusion_idsdk=false snap run fusion360`
 
 Ohh yes! You now will be able to see the Login Screen!
+For FusiontoURDF plugins refer https://github.com/syuntoku14/fusion2urdf.git

--- a/README.md
+++ b/README.md
@@ -6,12 +6,7 @@
 
 <b>This is the snap of [Autodesk Fusion 360](https://www.autodesk.com.au/products/fusion-360/overview)</b>
   
-<i>Fusion 360 is Integrated CAD, CAM, CAE, and PCB software. developed by Autodesk</i>
-  
 It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
-
-[![fusion360](https://snapcraft.io/fusion360/badge.svg)](https://snapcraft.io/fusion360)
-
 
 
 ## Install
@@ -20,20 +15,9 @@ It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
-## Update the snap
+- You might now be able to see the fusion 360 screen, but it asks you to login via web, but is unable to open a prompt on web
+- Close Fusion 360, Open a new terminal,
 
-`$ sudo snap refresh fusion360 --devmode`
+`$ fusion_idsdk=false snap run fusion360`
 
-## Update Fusion360 within the snap
-
-`$ fusion360.updater`
-
-## Known Issues:
-
-- [DXVK](https://github.com/doitsujin/dxvk) will not currently work [Wine bug# 45277](https://bugs.winehq.org/show_bug.cgi?id=45277)
->006b:fixme:vulkan:X11DRV_vkCreateWin32SurfaceKHR Application requires child window rendering, which is not implemented yet!
-
-- Fusion360.exe hangs after window being closed
-[Wine bug# 53286](https://bugs.winehq.org/show_bug.cgi?id=53286)
-
-- Floating toolbars
+Ohh yes! You now will be able to see the Login Screen!

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 `$ fusion_idsdk=false snap run fusion360`
 
 Ohh yes! You now will be able to see the Login Screen!
-For FusiontoURDF plugins refer https://github.com/syuntoku14/fusion2urdf.git
+- For FusiontoURDF plugins refer https://github.com/syuntoku14/fusion2urdf.git

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <h1 align="center">
   <img src="snap/gui/fusion360.png" alt="Project">
   <br />
-  Autodesk Fusion 360
+  Autodesk Fusion 360 for Ubuntu
 </h1>
 
-<b>This is the snap of [Autodesk Fusion 360 for Ubuntu](https://www.autodesk.com.au/products/fusion-360/overview)</b>
+<b>This is the snap of [Autodesk Fusion 360](https://www.autodesk.com.au/products/fusion-360/overview)</b>
   
 It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 `$ fusion_idsdk=false snap run fusion360`
 
 Ohh yes! You now will be able to see the Login Screen!
-- For FusiontoURDF plugins refer https://github.com/syuntoku14/fusion2urdf.git
+- For FusiontoURDF plugins refer the following
+ROS1: https://github.com/syuntoku14/fusion2urdf.git
+ROS2: https://github.com/kartiksoni01/fusion2urdf-ros2

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 
 Ohh yes! You now will be able to see the Login Screen!
 - For FusiontoURDF plugins refer the following
-ROS1: https://github.com/syuntoku14/fusion2urdf.git
-ROS2: https://github.com/kartiksoni01/fusion2urdf-ros2
+- ROS1: https://github.com/syuntoku14/fusion2urdf.git
+- ROS2: https://github.com/kartiksoni01/fusion2urdf-ros2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   Autodesk Fusion 360
 </h1>
 
-<b>This is the snap of [Autodesk Fusion 360](https://www.autodesk.com.au/products/fusion-360/overview)</b>
+<b>This is the snap of [Autodesk Fusion 360 for Ubuntu](https://www.autodesk.com.au/products/fusion-360/overview)</b>
   
 It works on Arch, Ubuntu, Fedora, Debian, and other major Linux distributions.
 


### PR DESCRIPTION
Hello there, 
Thank you for this repository, being able to launch fusion360 in ubuntu is such a convenient solution for roboticists like me. However the new fusion360 verification terminologies were unable to be bypassed through the current fusion bringup commands. So I just updated it by shutting off that sdk. Now things are looking pretty good.
Thanks again and cheers!